### PR TITLE
Remove stray conflict markers from parchment styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -241,7 +241,6 @@ st.markdown(
     max-width: 70ch;
     margin: 0.5rem auto 0;
 }}
-for-story-prologue-display
 .prologue-glyph {{
     display: flex;
     justify-content: center;
@@ -289,7 +288,8 @@ div[data-testid="stVerticalBlock"]:has(> div#prologue-anchor) .stCaption {{
 div[data-testid="stVerticalBlock"]:has(> div#prologue-anchor) .stButton button {{
     width: 100%;
     margin-top: 0.75rem;
-=======
+}}
+
 .parchment-card {{
     position: relative;
     padding: 1.25rem 1rem 1.1rem;


### PR DESCRIPTION
## Summary
- remove the stray `for-story-prologue-display` line and lingering conflict separator from the parchment CSS block
- restore the closing brace for the prologue button styles and add spacing before the parchment card rules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6113c75a083209a659909d0bdc353