### PR TITLE
Fix keep-alive workflow schedule

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,7 +1,7 @@
 name: Keep Streamlit Alive
 on:
   schedule:
-    - cron: '*/720 * * * *'   # every 720 minutes
+    - cron: '0 */12 * * *'    # every 12 hours
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- replace the invalid keep-alive cron expression with a valid schedule and update the inline comment

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/keep-alive.yml

------
https://chatgpt.com/codex/tasks/task_b_68d616310a1c832094e4c43cee6250f7