### PR TITLE
Adjust soundscape image layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -1377,7 +1377,7 @@ if selected_key:
                 if artwork_b64:
                     st.image(
                         f"data:image/png;base64,{artwork_b64}",
-                        use_column_width=True,
+                        use_container_width=True,
                     )
                 else:
                     st.markdown(


### PR DESCRIPTION
## Summary
- replace the soundscape artwork image call to use the modern `use_container_width` argument
- ran the Streamlit app locally to confirm the layout renders as expected

## Testing
- streamlit run app.py

------
https://chatgpt.com/codex/tasks/task_b_68d6169b928c8320bc24276c0c335f6a