### PR TITLE
Add merge check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,21 @@ on:
   pull_request:
 
 jobs:
+  merge-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check merge with origin/main
+        run: |
+          git fetch origin main
+          git merge --no-commit --no-ff origin/main
+
   build:
+    needs: merge-check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The `setup.py` scribe is a powerful incantation. It will:
 
 Should you feel the call to contribute a new story to the Scroll, your path is clear. The process is a meditation in three parts: composing the narrative, forging the soundscape, and weaving the elements together.
 
+> **Keep your scroll aligned.** Before pushing your changes, rebase your branch onto the latest `main` so that the automated merge check in CI can complete without conflict.
+
 Let us say you wish to add a new story called `"The River's Wisdom"` to the `"Birth of Dharma"` chapter.
 
 ### 1. Compose the Narrative


### PR DESCRIPTION
## Summary
- add a merge-check job to the CI workflow to ensure branches merge cleanly with main
- document the expectation that contributors rebase onto main before pushing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68db5ec8e5f8832ba8caf134eea1095e