### PR TITLE
Refine copy across prologue, narratives, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,61 +12,59 @@
     </a>
 </p>
 
-This is not just a project. It is a digital sanctuary, an interactive meditation on duty, doubt, and devotion. It is a place to witness ancient narratives come alive through animated glyphs, living soundscapes, and the timeless wisdom of the epics.
-
-*“Doubt is not defeat, but the fertile soil of wisdom.”*
+The Scroll of Dharma is an interactive story lab built with Streamlit. Animated glyphs, reactive themes, and scored soundscapes bring epic turning points into a focused reading flow. Pick a chapter, inspect the pressure on every hero, and track the consequences of each choice.
 
 ## ✨ The Experience
 
-Unfurl the scroll and choose your path. Each chapter is a unique journey, a different facet of the diamond that is Dharma.
+Load the app, make a call, and watch the interface respond.
 
-*   **Themed Narratives:** Immerse yourself in stories of conflict, choice, and transcendence, drawn from the heart of sacred texts.
-*   **Animated Glyphs:** Watch as symbols of doubt, resolve, and cosmic balance gently move and breathe, each telling a story of its own.
-*   **Living Soundscapes:** Let the curated audio guide your meditation. From the ambient chants of the Gita to the layered compositions of a kingdom's fall, each sound is a thread in the tapestry of the narrative.
-*   **Evocative Typography:** Each chapter is rendered in a unique typeface, carefully chosen to reflect its tone and spirit.
+*   **Story-first reading:** Each narrative foregrounds the stakes, the conflict, and the payoff—no filler, just the pivotal beats.
+*   **Instant visual shifts:** Chapter swaps trigger new typography, textures, and animated glyphs tuned to the scenario.
+*   **Sound on demand:** Optional soundscapes add weight to the moment without forcing autoplay.
+*   **Built for focus:** Minimal controls, fast loading assets, and a clean layout keep attention on the choice in front of you.
 
 ## 📜 The Chapters
 
-The Scroll of Dharma unfolds in five chapters, each a world unto itself.
+Five chapters cover the critical pivots of the epic. Each one surfaces a decision that tilts the world.
 
-*   **Gita Scroll:** Stand with Arjuna on the battlefield of Kurukshetra, where the whispers of doubt give way to the thunder of divine counsel.
-*   **Fall of Dharma:** Witness the gilded court where a game of dice unravels an empire, and silence becomes the loudest cry of protest.
-*   **Weapon Quest:** Journey into the wilderness of the self, where a warrior’s austerity earns him the weapons of the gods.
-*   **Birth of Dharma:** Travel back to the cosmic dawn, where creation cracks open not with a bang, but with a breath of harmonious invocation.
-*   **Trials of Karna:** Walk the noble, tragic path of the sun-born hero, a journey of loyalty, curses, and ultimate sacrifice where duty is tested against destiny.
+*   **Gita Scroll:** Arjuna halts a war, interrogates duty, and chooses how to fight.
+*   **Fall of Dharma:** A fixed dice game topples a kingdom while a court watches in silence.
+*   **Weapon Quest:** Training, divine trials, and discipline decide who earns celestial weapons.
+*   **Birth of Dharma:** Creation itself balances promises between fire, water, and motion.
+*   **Trials of Karna:** Loyalty, secrecy, and a fatal curse lock a hero into his final stand.
 
 *“To wield the divine, you must first dissolve the self.”*
 
-## 🚀 Unfurling the Scroll (Quick Start)
+## 🚀 Quick Start
 
-To begin your journey, you must first prepare the vessel. These incantations, whispered into your terminal, will bring the Scroll to life.
+Spin up the project with a standard Python workflow.
 
 **Prerequisites:**
 *   Python 3.11+
-*   `ffmpeg` must be on your system's PATH ([Download here](https://ffmpeg.org))
-*   Optional: A `cookies.txt` file in the root of the project to aid in fetching audio from the ether.
+*   `ffmpeg` on your system PATH ([Download here](https://ffmpeg.org))
+*   Optional: `cookies.txt` in the project root for authenticated audio downloads
 
-**The Ritual (PowerShell):**
+**Setup (PowerShell):**
 
 ```powershell
-# Create and enter the sacred space
+# Create a virtual environment
 python -m venv .venv
 .\.venv\Scripts\Activate.ps1
 
-# Invoke the setup scribe (installs dependencies, gathers fonts, and forges audio)
+# Install dependencies, download fonts, and build audio assets
 python setup.py
 
-# Unfurl the scroll
+# Launch the app
 streamlit run app.py
 ```
 
-The `setup.py` scribe is a powerful incantation. It will:
-- Ensure the sanctums for assets (audio, fonts, textures, svg) are prepared.
-- Gather the necessary Python libraries.
-- Verify the presence of `ffmpeg`.
-- Summon the sacred fonts from the Google Fonts heavens.
-- Forge the audio landscapes for each chapter.
-- Leave a `config.json` file, a map of the assets it has created.
+`setup.py` handles environment prep:
+- Creates asset directories for audio, fonts, SVGs, and textures.
+- Installs Python dependencies.
+- Confirms `ffmpeg` is available.
+- Downloads the required fonts.
+- Mixes the chapter soundscapes.
+- Writes a `config.json` manifest summarizing the generated assets.
 
 ## ✍️ The Scribe's Tools (A Guide for Contributors)
 

--- a/app.py
+++ b/app.py
@@ -51,14 +51,14 @@ def get_asset_path(subfolder: str, filename: str) -> Path:
 
 
 PROLOGUE_TEXT = """
-<p><strong>The scroll stirs awake.</strong> Amber glyphs rise from parchment, inviting you to breathe and listen before the teachings unfold.</p>
-<p>This illuminated manuscript will guide you through chapters of devotion, trial, and awakening. Let the prologue center your senses:</p>
+<p><strong>The scroll wakes.</strong> Glyphs flare. The page is waiting.</p>
+<p>Move with purpose:</p>
 <ul>
-    <li>Choose a chapter to attune the scroll's tapestry and typography.</li>
-    <li>Unfurl a story to reveal its glyph, meditation, and chant.</li>
-    <li>Invite the soundscape when you are ready to let the ambience resonate.</li>
+    <li>Pick a chapter to snap the visuals, fonts, and texture into a new mood.</li>
+    <li>Open a story to get the glyph, the conflict, and the resolution in one view.</li>
+    <li>Start the ambience when you want the soundscape to carry the scene.</li>
 </ul>
-<p>When your intention feels steady, begin your journey through the Scroll of Dharma.</p>
+<p>Lock in your focus. Choose a chapter. Begin.</p>
 """
 
 PROLOGUE_GLYPH = {

--- a/narrative.py
+++ b/narrative.py
@@ -16,182 +16,137 @@ NARRATIVES = {
     "gita_scroll": {
         "lotus_of_doubt": (
             "“My limbs fail me, my mouth is parched, my body trembles...”\n"
-            "The lotus trembles. Dharma fades.\n"
-            "Arjuna stands at the edge of battle, torn between duty and despair. The bow slips from his hand, not from weakness, but from the weight of compassion.\n"
-            "In the hush before the storm, the lotus whispers: Doubt is not defeat, but the fertile soil of wisdom.\n"
-            "He gazes at the faces before him-kin and teacher, friend and foe-each a reflection of his own heart.\n"
-            "The wind stirs the parchment, and petals fall. In this moment, the seeker is born."
+            "Arjuna freezes on the battle line while family and mentors wait for his bow.\n"
+            "Fight and he kills kin; retreat and duty collapses.\n"
+            "He forces the pause, demanding a path before the first arrow flies."
         ),
         "chakra_of_dharma": (
             "“You grieve for those who should not be grieved for...”\n"
-            "The chakra awakens. Dharma stirs.\n"
-            "Krishna’s voice is a river, gentle yet unyielding, carving a path through Arjuna’s confusion.\n"
-            "Action without attachment, he teaches, is the way of the wise.\n"
-            "The wheel turns, and with each revolution, the fog lifts. Duty becomes devotion, and the battlefield transforms into a temple of learning.\n"
-            "The seeker finds clarity in the counsel of the divine."
+            "Krishna answers the stalemate with ruthless clarity.\n"
+            "Act without clinging, he commands, or watch dharma die.\n"
+            "The wheel turns; confusion thins; the next move becomes inevitable."
         ),
         "spiral_of_vision": (
             "“Behold my cosmic form...”\n"
-            "Time devours all. Dharma transcends fear.\n"
-            "Krishna reveals his Vishvarupa, the infinite form. Galaxies swirl in his eyes, creation and destruction dance in his breath.\n"
-            "Arjuna beholds the spiral of existence-past, present, and future entwined.\n"
-            "Awe and terror mingle in his soul, and surrender becomes the only prayer.\n"
-            "The seeker bows, humbled by the vastness of dharma."
+            "Krishna shows the war’s true scale—worlds burning, worlds reborn.\n"
+            "Arjuna sees every life he might spare already consumed by time.\n"
+            "Terror flips to surrender; he accepts the role the cosmos demands."
         ),
         "sword_of_resolve": (
             "“Slay with equanimity...”\n"
-            "The scroll seals. The warrior rises.\n"
-            "Arjuna lifts his bow, not with anger, but with serene resolve.\n"
-            "He understands: to act is not to destroy, but to uphold the balance of the world.\n"
-            "The sword gleams, a beacon of purpose. The final chapter is written in the fire of courage and the ink of compassion.\n"
-            "The seeker becomes the hero, and dharma is restored."
+            "Arjuna picks up the bow, steady now.\n"
+            "He fights to defend order, not to feed anger.\n"
+            "Resolve replaces panic; the campaign finally begins."
         ),
     },
     "fall_of_dharma": {
         "game_of_fate": (
             "“The court is gilded, but the air is heavy.”\n"
-            "Shakuni lifts the dice-bones of betrayal, carved from vengeance.\n"
-            "They do not roll. They choose.\n"
-            "Yudhishthira wagers not gold, but virtue. Pride blinds the wise. Ego deafens the just.\n"
-            "With each throw, dharma frays. The wheel does not turn-it cracks.\n"
-            "And Draupadi, untouched by the game, becomes its cruelest stake."
+            "Loaded dice decide the empire while Yudhishthira gambles reputation for pride.\n"
+            "Each throw strips another safeguard.\n"
+            "By the time Draupadi is wagered, the kingdom is already lost."
         ),
         "silence_of_protest": (
             "“The dice have fallen. The wager is made.”\n"
-            "Bhishma, the grand pillar, stands unmoved. His vow, once noble, now binds him in chains.\n"
-            "Vidura, the voice of wisdom, speaks not. His words are drowned in royal pride.\n"
-            "Silence spreads like smoke. Not from fire-but from fear.\n"
-            "Dharma does not die in battle. It dies when the righteous choose quiet."
+            "Bhishma’s oath shackles him, Vidura’s warnings die in his throat.\n"
+            "No elder moves, so the outrage hardens into law.\n"
+            "Dharma falls not from defeat but from complicity."
         ),
         "divine_intervention": (
             "“She stands in the court of kings-alone, yet unshaken.”\n"
-            "Her voice trembles, but her spirit does not.\n"
-            "Hands raised, eyes closed, she calls not for vengeance, but for grace.\n"
-            "A whisper-‘Govinda’-pierces the veil. And the fabric flows, endless as compassion.\n"
-            "She is not stripped. She is sanctified."
+            "Draupadi calls Krishna before the assembly can finish the assault.\n"
+            "The cloth keeps coming; the conspirators freeze.\n"
+            "The court witnesses mercy as judgment—and the revolt seeds itself."
         ),
     },
     "weapon_quest": {
         "forest_of_austerity": (
             "“Withdraw from the world, and the world shall reveal its secrets.”\n"
-            "Arjuna steps into the forest, not as a warrior, but as a seeker. The clang of battle fades. In its place: rustling leaves, distant chants, and the breath of the earth.\n"
-            "His bow rests beside him. His armor gathers dust. He wears only resolve.\n"
-            "Days stretch into weeks. Hunger gnaws. The body weakens, but the spirit sharpens. Each breath is a mantra. Each moment, a mirror.\n"
-            "The forest watches. It does not speak, but it teaches:\n"
-            "- The stillness of the lake reflects the chaos within.\n"
-            "- The roots of ancient trees whisper of forgotten truths.\n"
-            "- The fireflies dance like astras waiting to be earned.\n"
-            "Arjuna’s mind wanders-to Draupadi’s laughter, to Krishna’s gaze, to the faces he must one day face. But he returns, again and again, to the silence.\n"
-            "One night, beneath a moon veiled in mist, he sees a figure in meditation-a sage carved from starlight. The sage does not open his eyes, but Arjuna hears:\n"
-            "“To wield the divine, you must first dissolve the self.”\n"
-            "Arjuna bows. Not to the sage, but to the path.\n"
-            "The forest does not test him. It transforms him.\n"
-            "The seeker becomes the vessel."
+            "Arjuna abandons steel for stillness and lets hunger and doubt grind him down.\n"
+            "If he breaks, the quest ends; if he endures, the gods take notice.\n"
+            "He holds the vigil, and the forest answers with the next guide."
         ),
         "shiva_and_the_hunter": (
             "“Strike not in anger, but in truth.”\n"
-            "A wild boar charges. Arjuna’s arrow flies. But another pierces first.\n"
-            "A hunter stands before him-rugged, radiant, unknowable.\n"
-            "They clash, not in hatred, but in revelation. Each blow is a question. Each parry, a prayer.\n"
-            "When the dust settles, the hunter smiles. The illusion fades.\n"
-            "Shiva stands revealed. The seeker is blessed with the Pashupatastra-the weapon of dissolution and grace."
+            "A boar falls to two arrows; Arjuna demands the prize.\n"
+            "The hunter matches him strike for strike until arrogance cracks.\n"
+            "Shiva reveals himself and gifts the Pashupatastra to the disciplined challenger."
         ),
         "celestial_audience": (
             "“Come forth, son of Indra.”\n"
-            "Arjuna ascends to Amaravati, the city of gods. Music flows like rivers. Stars bow in rhythm.\n"
-            "Indra embraces his son, and the heavens open their vaults.\n"
-            "He learns the dance of astras-the thunderbolt, the wind blade, the fire wheel.\n"
-            "Urged by sages, trained by celestials, Arjuna becomes more than mortal.\n"
-            "The seeker becomes the wielder, and the cosmos lends him its fury."
+            "Heaven summons Arjuna to trade mortal instincts for celestial drills.\n"
+            "Every lesson ties a weapon to a moral boundary.\n"
+            "He leaves with power measured by discipline, ready for the war ahead."
         ),
         "trial_of_heaven": (
             "“Power without humility is ruin.”\n"
-            "Arjuna is tested-not by enemies, but by temptation.\n"
-            "The apsaras beckon. The halls shimmer. Pride stirs.\n"
-            "But he bows to wisdom, not indulgence. He chooses restraint over revelry.\n"
-            "The gods nod. The astras glow.\n"
-            "The seeker passes the trial-not by conquest, but by character."
+            "Heaven offers Arjuna indulgence to see if the new arsenal controls him.\n"
+            "He turns away, keeping his vow sharper than any blade.\n"
+            "The gods endorse him; the mission stays on course."
         ),
     },
     "birth_of_dharma": {
         "cosmic_egg": (
             "“From silence, the seed of creation cracked.”\n"
-            "The Brahmanda floats in the void-golden, whole, waiting.\n"
-            "No gods yet speak. No winds yet stir. But within the egg, time coils like a serpent.\n"
-            "A crack forms-not of violence, but of yearning.\n"
-            "From this fracture, breath emerges. Space unfolds. The first vibration hums.\n"
-            "The spiral glyph pulses. The cosmos inhales.\n"
-            "The seeker glimpses the origin-not as myth, but as memory."
+            "The cosmic egg holds every possibility and every collapse.\n"
+            "One fracture decides whether the universe ignites or stays void.\n"
+            "It splits—the first breath commits reality to motion."
         ),
         "first_flame": (
             "“Agni rises-not to burn, but to illuminate.”\n"
-            "From the ash of silence, the flame dances.\n"
-            "It does not consume. It reveals.\n"
-            "Agni bears the spark of sacrifice, the warmth of devotion, the fire of transformation.\n"
-            "He flickers between realms, a messenger of intent.\n"
-            "The flame glyph glows. The scroll warms.\n"
-            "The seeker learns: to offer is to awaken."
+            "Fire tests every offering; refuse to feed it and creation stalls.\n"
+            "The flame accepts the vow and turns devotion into power.\n"
+            "Sacrifice becomes the currency of progress."
         ),
         "river_oath": (
             "“Flow not to conquer, but to cleanse.”\n"
-            "Saraswati emerges, veiled in mist, her currents braided with wisdom.\n"
-            "She does not rush. She remembers.\n"
-            "Her waters carry restraint, clarity, and the promise of truth.\n"
-            "The river glyph ripples. The parchment softens.\n"
-            "The seeker listens-not to words, but to whispers."
+            "Saraswati’s current offers a choice: drown in noise or ride toward clarity.\n"
+            "Those who enter with deceit are swept aside.\n"
+            "The oath to speak truth keeps the waters calm."
         ),
         "wheel_turns": (
             "“Dharma is not a rule. It is a rhythm.”\n"
-            "From flame and flow, the wheel awakens.\n"
-            "It does not command. It turns.\n"
-            "Each spoke a path. Each revolution a lesson.\n"
-            "The chakra spins-not to dominate, but to balance.\n"
-            "The wheel glyph pulses. The scroll hums.\n"
-            "The seeker stands at the center-not above, but within."
+            "The wheel locks the elements into order; ignore its timing and harmony shatters.\n"
+            "Each spoke demands a choice between imbalance and alignment.\n"
+            "When it turns smoothly, creation stays upright."
         ),
         "balance_restored": (
             "“Thus was Dharma born-not imposed, but invoked.”\n"
-            "The egg cracked. The flame rose. The river flowed. The wheel turned.\n"
-            "Creation did not begin with command. It began with harmony.\n"
-            "The scroll closes, but the rhythm continues.\n"
-            "The seeker walks forward-not with answers, but with alignment."
+            "Creation holds only because each force keeps its promise.\n"
+            "Break one vow and the cycle collapses.\n"
+            "Keep them, and balance stays restored."
         ),
     },
     "trials_of_karna": {
         "suns_gift": (
             "“Born of the Sun, yet cast to the shadows.”\n"
-            "Karna awakens with divine armor and earrings-gifts of Surya, radiant and silent.\n"
-            "The world does not know him, but the cosmos already sings his name.\n"
-            "He walks among mortals with celestial grace, yet bears the ache of abandonment.\n"
-            "The seeker is marked-not by lineage, but by light."
+            "Karna arrives armed with celestial armor but no pedigree.\n"
+            "Keep the secret and survive as an outcast; reveal it and risk rejection.\n"
+            "He chooses anonymity, sharpening resolve in isolation."
         ),
         "brahmin_curse": (
             "“Compassion is a blade that cuts both ways.”\n"
-            "Karna, moved by mercy, kills a cow by mistake. The Brahmin curses him:\n"
-            "‘In your moment of need, memory shall fail.’\n"
-            "The curse coils around his fate, quiet but fatal.\n"
-            "The seeker learns: even kindness must carry consequence."
+            "A single misfired arrow earns Karna a curse: forget every skill when it matters most.\n"
+            "He accepts the judgment to honor the grieving Brahmin.\n"
+            "Mercy now guarantees a fatal gap later."
         ),
         "friends_vow": (
             "“Loyalty is a crown-and a chain.”\n"
-            "Duryodhana offers Karna a throne. Karna accepts-not for power, but for gratitude.\n"
-            "He stands beside the one who saw his worth, even as dharma trembles.\n"
-            "In friendship, he finds purpose. In purpose, he finds chains.\n"
-            "The seeker chooses loyalty over lineage."
+            "Duryodhana elevates Karna, demanding allegiance in return.\n"
+            "Honor the bond and fight against dharma, or betray the one ally who believed in him.\n"
+            "Karna locks the vow, knowing it fixes his fate."
         ),
         "birth_revealed": (
             "“Truth arrives-but not always in time.”\n"
-            "Kunti speaks. Karna is her son-sun-born, Pandava by blood.\n"
-            "But the war is near, and Karna chooses silence over reunion.\n"
-            "Identity flickers, but loyalty holds firm.\n"
-            "The seeker carries truth-not to claim, but to protect."
+            "Kunti finally names him her son; the Pandavas become his brothers.\n"
+            "Switch sides and live, or keep the oath and march toward certain loss.\n"
+            "He shields the secret to protect her honor and his promise."
         ),
         "final_arrow": (
             "“The wheel sinks. The memory fades. The arrow flies.”\n"
-            "On the field of Kurukshetra, Karna’s chariot falters. His mind blanks. Fate strikes.\n"
-            "He dies with dignity, not victory. Dharma watches.\n"
-            "The sun sets-not in defeat, but in grace.\n"
-            "The seeker falls-not forgotten, but fulfilled."
+            "Karna’s chariot stalls, the curse erases his mantras, and Arjuna closes in.\n"
+            "He begs for time; the battlefield denies it.\n"
+            "He falls, keeping the vow that cost him everything."
         ),
     },
 }


### PR DESCRIPTION
## Summary
- tighten the Streamlit prologue copy so the introduction speaks in short, action-driven prompts
- rework every narrative entry to foreground the conflict, stakes, and ultimate choice or payoff
- update the README overview, chapter blurbs, and quick start section with direct, benefit-focused messaging

## Testing
- python -m compileall app.py narrative.py
- python - <<'PY'
import markdown
from pathlib import Path
html = markdown.markdown(Path('README.md').read_text(encoding='utf-8'))
print(html.splitlines()[0])
print('Rendered length:', len(html))
PY


------
https://chatgpt.com/codex/tasks/task_b_68db5ec67304832b8650f9dabc09e395