### PR TITLE
Improve soundscape artwork accessibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ import streamlit as st
 from pathlib import Path
 import re
 import base64
+import html
 
 
 
@@ -1683,13 +1684,26 @@ if selected_key:
             "Let the unseen choir swell softly around the unfolding tale.",
         )
 
+        chapter_title = CHAPTER_TITLES.get(
+            selected_chapter,
+            selected_chapter.replace("_", " ").title(),
+        )
+        soundscape_alt = (
+            f"Artwork for the {chapter_title} soundscape—{soundscape_story}"
+        )
+        soundscape_alt_html = html.escape(soundscape_alt, quote=True)
+        placeholder_label = html.escape(
+            f"Om symbol representing the {chapter_title} soundscape",
+            quote=True,
+        )
+
         with st.container():
             st.markdown('<div class="soundscape-panel">', unsafe_allow_html=True)
             art_col, info_col = st.columns([1.05, 1.6])
             with art_col:
                 if artwork_url:
                     st.markdown(
-                        f"<img src=\"{artwork_url}\" alt=\"Soundscape artwork\" style=\"width:100%;\" />",
+                        f"<img src=\"{artwork_url}\" alt=\"{soundscape_alt_html}\" style=\"width:100%;\" />",
                         unsafe_allow_html=True,
                     )
                 else:
@@ -1701,12 +1715,12 @@ if selected_key:
                 with art_col:
                     if artwork_url:
                         st.markdown(
-                            f"<img src=\"{artwork_url}\" alt=\"Soundscape artwork\" style=\"width:100%;\" />",
+                            f"<img src=\"{artwork_url}\" alt=\"{soundscape_alt_html}\" style=\"width:100%;\" />",
                             unsafe_allow_html=True,
                         )
                     else:
                         st.markdown(
-                            "<div style='font-size:3rem;text-align:center;'>🕉️</div>",
+                            f"<div role='img' aria-label=\"{placeholder_label}\" style='font-size:3rem;text-align:center;'>🕉️</div>",
                             unsafe_allow_html=True,
                         )
                     st.caption("Artwork from the illuminated scroll.")


### PR DESCRIPTION
## Summary
- derive the soundscape artwork alt text from chapter titles and descriptions for clearer narration context
- add an accessible aria-label to the Om-symbol placeholder when artwork is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dba8e9de6c832b985e64554efcd9bb